### PR TITLE
Attempt merge

### DIFF
--- a/bin/detector.dart
+++ b/bin/detector.dart
@@ -82,9 +82,9 @@ Future attemptMerge(PullRequest pr1, PullRequest pr2, String repoPath) async {
   ProcessResult mergeResult = await mergeBranch(pr2, repoPath);
   ProcessResult deleted = await Process.run('git', ['branch', '-D', tempBranchName(pr1)], workingDirectory: repoPath);
   if (mergeResult.exitCode != 0) {
-    print('FAILURE ${remoteBranchName(pr2)} => ${remoteBranchName(pr1)}');
+    print('FAILURE ${simpleName(pr2)} => ${simpleName(pr1)}');
   } else {
-    print('SUCCESS ${remoteBranchName(pr2)} => ${remoteBranchName(pr1)}');
+    print('SUCCESS ${simpleName(pr2)} => ${simpleName(pr1)}');
   }
 }
 

--- a/bin/detector.dart
+++ b/bin/detector.dart
@@ -7,33 +7,28 @@ import "package:github/server.dart";
 
 class Configuration {
   String authToken;
-  String accountName;
+  String originAccountName;
   String repoName;
+  String localRepoPath;
 }
 
 RepositorySlug makeRepoSlug(Configuration config) =>
-    new RepositorySlug(config.accountName, config.repoName);
+new RepositorySlug(config.originAccountName, config.repoName);
 
 /// Given a github repository, finds all open PRs, and attempts to merge
 /// each PR.  If there are any merge conflicts, returns the previous
 /// successful branch that was merged, and the branch that caused the
 /// merge conflict.
 main(List<String> args) async {
-  var config = await getConfiguration(args);
+  Configuration config = await getConfiguration(args);
   var auth = new Authentication.withToken(config.authToken);
   var githubClient = createGitHubClient(auth: auth);
 
   // make a list of pull requests
-  var repoStream = githubClient.pullRequests.list(makeRepoSlug(config));
-  var repoList = await repoStream.toList();
-  repoList.forEach((PullRequest pr) {
-    print("""
-      PR title: ${pr.title}
-      Github Repo User: ${pr.base.user.login}
-      Github Repo: ${pr.base.repo.name}
-      branch name: ${pr.base.ref}
-    """);
-  });
+  var pullRequestStream = githubClient.pullRequests.list(makeRepoSlug(config));
+  var pullRequestList = await pullRequestStream.toList();
+
+  await detectConflicts(pullRequestList, config.localRepoPath);
   exit(0);
 }
 
@@ -41,14 +36,15 @@ main(List<String> args) async {
 Future<Configuration> getConfiguration(List<String> args) async {
   var parser = new ArgParser();
   var results = parser.parse(args);
-  if (results.rest.length != 2) {
-    print('Usage: detector [github account] [repository]');
+  if (results.rest.length != 3) {
+    print('Usage: detector [github account] [repository] [local repo path]');
     exit(1);
   }
   return new Configuration()
-    ..accountName = results.rest[0]
+    ..originAccountName = results.rest[0]
     ..repoName = results.rest[1]
-    ..authToken = await getAuthToken();
+    ..authToken = await getAuthToken()
+    ..localRepoPath = results.rest[2];
 }
 
 /// Attempts to read .merge_conflict_detector_config in the user's home
@@ -58,7 +54,63 @@ Future<String> getAuthToken() async {
   var homeDir = Platform.environment['HOME'];
   var configFile = new File('$homeDir/.merge_conflict_detector_config');
   if (await configFile.exists()) return configFile.readAsString();
+
   print('no config file found.  Enter your github auth token:');
   var authToken = stdin.readLineSync();
   configFile.writeAsString(authToken);
+  return authToken;
+}
+
+detectConflicts(List<PullRequest> pullRequests, String localRepoPath) async {
+//  pullRequests.forEach((PullRequest pr) {
+//    print("""
+//      PR title: ${pr.title}
+//      Github Repo User: ${pr.base.user.login}
+//      Github Repo: ${pr.base.repo.name}
+//      branch name: ${pr.base.ref}
+//    """);
+//  });
+  await attemptMerge(pullRequests[0], pullRequests[1], localRepoPath);
+}
+
+attemptMerge(PullRequest pr1, PullRequest pr2, String repoPath) async {
+  await addRemote(pr1, repoPath);
+  await addRemote(pr2, repoPath);
+  await fetchRemote(pr1, repoPath);
+  await fetchRemote(pr2, repoPath);
+  await checkoutBranch(pr1, repoPath);
+  await mergeBranch(pr2, repoPath);
+//  print('${pr1.base.user.login}/${pr1.base.ref} <= ${pr2.base.user.login}/${pr2.base.ref}');
+}
+
+Future addRemote(PullRequest pr, String repoPath) async {
+  var args = ['remote', 'add', remoteName(pr), remoteUrl(pr)];
+  await Process.run('git', args, workingDirectory: repoPath);
+}
+String remoteName(PullRequest pr) => 'merge_conflict_detector/${pr.base.user.login}';
+String remoteUrl(PullRequest pr) => pr.base.repo.cloneUrls.ssh;
+String remoteBranchName(PullRequest pr) => 'remotes/${remoteName(pr)}/${pr.base.ref}';
+String tempBranchName(PullRequest pr) => 'merge_conflict_detector/${pr.base.user.login}/${pr.base.ref}';
+
+Future fetchRemote(PullRequest pr, String repoPath) async {
+  var args = ['fetch', remoteName(pr)];
+  await Process.run('git', args, workingDirectory: repoPath);
+}
+
+Future checkoutBranch(PullRequest pr, String repoPath) async {
+  var args = ['checkout', remoteBranchName(pr)];
+  await Process.run('git', args, workingDirectory: repoPath);
+  var args2 = ['checkout', '-b', tempBranchName(pr)];
+  await Process.run('git', args2, workingDirectory: repoPath);
+}
+
+Future<ProcessResult> mergeBranch(PullRequest pr, String repoPath) async {
+  var args = ['merge', '--no-commit', '--no-ff', remoteBranchName(pr)];
+  ProcessResult result = await Process.run('git', args, workingDirectory: repoPath);
+  print('merged? ${result.stdout}');
+  print('merge error? ${result.stderr}');
+  print('exit code: ${result.exitCode}');
+  await Process.run('git', ['reset', '--hard'], workingDirectory: repoPath);
+  await Process.run('git', ['checkout', 'master'], workingDirectory: repoPath);
+  return result;
 }


### PR DESCRIPTION
Now, a local repo path can be provided.  That repo will be used by `detector.dart` to pull and attempt merges:

```
Usage: detector [github account] [repository] [local repo path]
```

Currently, `detector.dart` attempts all combinations and displays the following output:

```
FAILURE username/branchname => username/branchname
SUCCESS username/branchname => username/branchname
...
```

This is currently pretty messy (all in one file) but it's a start

@aaronhoffman 
